### PR TITLE
Refactor workflows with LangChain and LangGraph

### DIFF
--- a/src/processors/embedder.py
+++ b/src/processors/embedder.py
@@ -1,15 +1,27 @@
+"""Embedding utilities built on top of LangChain."""
+
 from typing import List
-from openai import OpenAI
 
 from config import OPENAI_API_KEY, EMBEDDING_MODEL
 
+# LangChain recently moved the OpenAI wrappers into a separate package.  We try
+# to import from ``langchain_openai`` first and fall back to the legacy location
+# for older versions.  This keeps the code compatible with a wider range of
+# LangChain releases.
+try:  # pragma: no cover - exercised in tests via patching
+    from langchain_openai import OpenAIEmbeddings
+except Exception:  # pragma: no cover
+    from langchain.embeddings.openai import OpenAIEmbeddings  # type: ignore
+
 
 class Embedder:
-    """Generate embeddings using OpenAI."""
+    """Generate embeddings using LangChain's ``OpenAIEmbeddings`` wrapper."""
 
     def __init__(self) -> None:
-        self.client = OpenAI(api_key=OPENAI_API_KEY)
+        self.client = OpenAIEmbeddings(
+            model=EMBEDDING_MODEL, openai_api_key=OPENAI_API_KEY
+        )
 
     def embed(self, texts: List[str]) -> List[List[float]]:
-        response = self.client.embeddings.create(model=EMBEDDING_MODEL, input=texts)
-        return [data.embedding for data in response.data]
+        """Embed a list of texts and return the raw vectors."""
+        return self.client.embed_documents(texts)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -4,23 +4,23 @@ os.environ["OPENAI_API_KEY"] = "test"
 from src.main import LectureProcessor
 
 
-class DummyResponse:
+class DummyLLMResponse:
     def __init__(self, text: str):
-        self.output = [type('obj', (object,), {'content': [type('c', (object,), {'text': text})()]})()]
+        self.content = text
 
 
 def fake_embed(texts):
     return [[float(len(t))] for t in texts]
 
 
-def fake_response(*args, **kwargs):
-    return DummyResponse("answer")
+def fake_llm(*args, **kwargs):
+    return DummyLLMResponse("answer")
 
 
 def test_document_and_qa_workflow():
     processor = LectureProcessor()
     with patch('src.processors.embedder.Embedder.embed', side_effect=fake_embed), \
-         patch.object(processor.qa_workflow.client.responses, 'create', side_effect=fake_response):
+         patch('src.workflows.qa_workflow.ChatOpenAI.invoke', side_effect=fake_llm):
         processor.process_document("examples/sample_pdfs/sample.pdf")
         answer = processor.ask_question("What does the document say?")
         assert answer == "answer"


### PR DESCRIPTION
## Summary
- use LangChain's OpenAIEmbeddings and ChatOpenAI wrappers
- add in-memory `SimpleVectorStore` alongside Weaviate wrapper
- orchestrate document and QA flows with LangGraph state graphs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2afcbdb8832a90c0c9b82fc8f9e0